### PR TITLE
Move 'global' flags to opts

### DIFF
--- a/resources_captest/workflowTemplate-cd-simple.yaml
+++ b/resources_captest/workflowTemplate-cd-simple.yaml
@@ -68,8 +68,8 @@ spec:
               value: "{{workflow.parameters.ARGOCD_APP}}"
             - name: serverUrl
               value: "{{workflow.parameters.ARGOCD_SERVER}}"
-            - name: flags
-              value: "--insecure --plaintext"
+            - name: opts
+              value: '--insecure --plaintext'
       - - name: wait
           templateRef:
             name: argo-hub.argocd.0.0.1
@@ -80,8 +80,10 @@ spec:
               value: "{{workflow.parameters.ARGOCD_APP}}"
             - name: serverUrl
               value: "{{workflow.parameters.ARGOCD_SERVER}}"
+            - name: opts
+              value: '--insecure --plaintext'
             - name: flags
-              value: '--health --insecure --plaintext'
+              value: '--health'
       # - - name: canary-test
       #     template: service-test
       # - - name: slack-announce-finish-deployment


### PR DESCRIPTION
Adding those items as flags works fine, but the 'opts' field can handle global options instead of command line flags. this may help to logically separate server config from command flags See [sync docs](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/sync.md) or [workflow template](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/workflowTemplate.yaml#L31-L33)